### PR TITLE
[DATABASE] Mudando a forma de conexão

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ APP_PORT=
 DB_USER=""
 DB_PASS=""
 DB_NAME=""
+DB_HOST=""
+DB_URL=""

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -16,13 +16,15 @@ module.exports = {
             useFindAndModify: false,
         };
 
+        const {DB_USER, DB_PASS, DB_HOST, DB_NAME, DB_URL } = process.env;
+        const url = DB_URL || `mongodb+srv://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_NAME}?retryWrites=true&w=majority`; 
         db.connect(
-            `mongodb+srv://${process.env.DB_USER}:${process.env.DB_PASS}@hackershawee-ws5ib.mongodb.net/${process.env.DB_NAME}?retryWrites=true&w=majority`,
+            url,
             dbOptions
         );
 
         db.connection.on("connected", () => {
-            console.log("MONGODB conectado com sucesso!");
+            console.log(`MONGODB conectado com sucesso!\nurl: ${url}`);
         });
 
         db.connection.on("err", (err) => {


### PR DESCRIPTION
Foi acrescentado duas variaveis de ambiente para facilitar o desenvolvimento
usando mongodb local, uma vez que as duas formas de conexão são por url,
fica mais fácil configurarmos a url no .env, além de adicionar uma variável
DB_HOST, caso seja necessário hospedar o mongo em outro servidor.

+ DB_URL no .env
+ DB_HOST no .env